### PR TITLE
Remove `-chart` from subchart references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,20 @@ helm install --create-namespace -n ack-system ack-chart \
 
 By default, when installing the `ack-chart`, **none of the subcharts are
 installed**. To enable a subchart, set the value associated with the ACK
-controller - either using `--set SERVICE-chart.enabled=true` or by configuring
+controller - either using `--set SERVICE.enabled=true` or by configuring
 the option in your `values.yaml` file. For example, to enable the
-`s3-controller`, enable the `s3-chart` like so:
+`s3-controller`, enable using the `s3` path like so:
 ```yaml
-s3-chart:
+s3:
   enabled: true
 ```
 
 Helm exposes all of the values for the underlying subcharts, just use the name
-of the subchart as the parent key and provide any overrides in the same
+of the service as the parent key and provide any overrides in the same
 structure as the subchart expects. For example, to update the `aws.region` for
-the `s3-chart`:
+the `s3`:
 ```yaml
-s3-chart:
+s3:
   enabled: true
   aws:
     region: "us-east-1"

--- a/values.yaml
+++ b/values.yaml
@@ -1,40 +1,40 @@
-apigatewayv2-chart:
+apigatewayv2:
   enabled: false
-applicationautoscaling-chart:
+applicationautoscaling:
   enabled: false
-cloudtrail-chart:
+cloudtrail:
   enabled: false
-dynamodb-chart:
+dynamodb:
   enabled: false
-ec2-chart:
+ec2:
   enabled: false
-ecr-chart:
+ecr:
   enabled: false
-eks-chart:
+eks:
   enabled: false
-eventbridge-chart:
+eventbridge:
   enabled: false
-iam-chart:
+iam:
   enabled: false
-kms-chart:
+kms:
   enabled: false
-lambda-chart:
+lambda:
   enabled: false
-memorydb-chart:
+memorydb:
   enabled: false
-pipes-chart:
+pipes:
   enabled: false
-prometheusservice-chart:
+prometheusservice:
   enabled: false
-rds-chart:
+rds:
   enabled: false
-s3-chart:
+s3:
   enabled: false
-sagemaker-chart:
+sagemaker:
   enabled: false
-sfn-chart:
+sfn:
   enabled: false
-sns-chart:
+sns:
   enabled: false
-sqs-chart:
+sqs:
   enabled: false


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1800

Description of changes:
The `Chart.yaml` file uses aliases to refer to the subcharts that specifically remove the need for `-chart` suffixes in `values.yaml`. This pull request updates the README to use the direct service name when overriding `values.yaml`, and updates the default `values.yaml` with the correct subchart keys.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
