### PR TITLE
Fix the semver regex for the release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,7 +2,7 @@ name: Create Release
 
 on:
   push:
-    tags: ['[0-9].[0-9]+.[0-9]+']
+    tags: ['^\d+\.\d+\.\d+$']
 
 
 permissions:


### PR DESCRIPTION
Looks like the Github releases stopped working exactly after 9.0.0 :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
