### PR TITLE
Fix tag pattern in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -2,7 +2,7 @@ name: Create Release
 
 on:
   push:
-    tags: ['^\d+\.\d+\.\d+$']
+    tags: ['[0-9]+.[0-9]+.[0-9]+']
 
 
 permissions:


### PR DESCRIPTION
Replacing the previous pattern `'^\d+\.\d+\.\d+$'` with
`'[0-9]+.[0-9]+.[0-9]+'` to ensure better compatibility with github
actions regex patterns.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
